### PR TITLE
#5 - Converted our Docker image to use Alpine as its base

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
     ports:
       - 8080:80
     volumes:
-      - ./resources:/var/www/resources
+      - ./resources:/var/www/app/resources


### PR DESCRIPTION
Well... That was quite an awesome reduction in image size:

```
REPOSITORY               TAG               IMAGE ID       CREATED             SIZE
pickle-web-alpine        latest            24339e785205   3 minutes ago       54.3MB
pickle-web-apache        latest            b0ef2b2e9a89   14 seconds ago      219MB
```